### PR TITLE
Handle the file tagging feature of the encrypted & signed files

### DIFF
--- a/patches/openfile.c.patch
+++ b/patches/openfile.c.patch
@@ -1,0 +1,40 @@
+diff --git a/g10/openfile.c b/g10/openfile.c
+index 42d4708..6da1b3b 100644
+--- a/g10/openfile.c
++++ b/g10/openfile.c
+@@ -183,7 +183,6 @@ open_outfile (gnupg_fd_t out_fd, const char *iname, int mode,
+               int restrictedperm, iobuf_t *a)
+ {
+   int rc = 0;
+-
+   *a = NULL;
+   if (out_fd != GNUPG_INVALID_FD)
+     {
+@@ -263,7 +262,6 @@ open_outfile (gnupg_fd_t out_fd, const char *iname, int mode,
+             }
+           name = buf;
+         }
+-
+       rc = 0;
+       while ( !overwrite_filep (name) )
+         {
+@@ -299,8 +297,18 @@ open_outfile (gnupg_fd_t out_fd, const char *iname, int mode,
+     }
+ 
+   if (*a)
++  {
++	if (mode == 0 || mode == 2) {
++          int fd = iobuf_get_fd(*a);
++
++	  if (mode == 0 && restrictedperm == 1) {
++	      __tag_new_file(fd);
++    	    } else {
++	      __setfdbinary(fd);
++    	    }
++	}
+     iobuf_ioctl (*a, IOBUF_IOCTL_NO_CACHE, 1, NULL);
+-
++  }
+   return rc;
+ }
+ 

--- a/patches/openfile.c.patch
+++ b/patches/openfile.c.patch
@@ -1,5 +1,5 @@
 diff --git a/g10/openfile.c b/g10/openfile.c
-index 42d4708..6da1b3b 100644
+index 42d4708..7689c2c 100644
 --- a/g10/openfile.c
 +++ b/g10/openfile.c
 @@ -183,7 +183,6 @@ open_outfile (gnupg_fd_t out_fd, const char *iname, int mode,
@@ -18,11 +18,12 @@ index 42d4708..6da1b3b 100644
        rc = 0;
        while ( !overwrite_filep (name) )
          {
-@@ -299,8 +297,18 @@ open_outfile (gnupg_fd_t out_fd, const char *iname, int mode,
+@@ -299,8 +297,20 @@ open_outfile (gnupg_fd_t out_fd, const char *iname, int mode,
      }
  
    if (*a)
 +  {
++#ifdef __MVS__
 +	if (mode == 0 || mode == 2) {
 +          int fd = iobuf_get_fd(*a);
 +
@@ -32,6 +33,7 @@ index 42d4708..6da1b3b 100644
 +	      __setfdbinary(fd);
 +    	    }
 +	}
++#endif
      iobuf_ioctl (*a, IOBUF_IOCTL_NO_CACHE, 1, NULL);
 -
 +  }


### PR DESCRIPTION
With this feature:

- We will tag the **encrypted** files, **signed** files in **non-armor mode** as binary. 
- In **armor** mode they will be tagged as **Ascii**.
- Further **revocation certificates** are tagged as **Ascii**.